### PR TITLE
The burn function was reverting different error message

### DIFF
--- a/test/foundry/LoreumToken.t.sol
+++ b/test/foundry/LoreumToken.t.sol
@@ -90,7 +90,7 @@ contract Deployment is Utility {
         hevm.startPrank(premintReceiver);
 
         if (burnAmount > premintAmount) {
-            hevm.expectRevert("ERC20: transfer amount exceeds balance");
+            hevm.expectRevert("ERC20: burn amount exceeds balance");
             LORE.burn(burnAmount);
         }
         else {


### PR DESCRIPTION
The burn function was getting different error messages.

path: `loreum-token/lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol`

```
283        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
```